### PR TITLE
Fix/send ocurred at on final result assigment

### DIFF
--- a/src/components/modal/components/ModalContent.tsx
+++ b/src/components/modal/components/ModalContent.tsx
@@ -51,6 +51,7 @@ function ModalContentComponent(props: ContentProps): React.ReactElement {
           orgUnit: event?.orgUnit,
           program: event?.program,
           enrolledAt:event?.occurredAt,
+          occurredAt:event?.occurredAt,
           trackedEntity: event?.trackedEntity,
           events: [
             {

--- a/src/utils/tei/formatPostBody.ts
+++ b/src/utils/tei/formatPostBody.ts
@@ -65,7 +65,6 @@ export const promoteTeiPostBody = (students: any, dataValues: any, performancePr
             trackedEntityType,
             enrollments: [
                 {
-                    attributes,
                     program: enrollments[0]?.program,
                     status: "COMPLETED",
                     occurredAt: enrollmentDate,


### PR DESCRIPTION
This PR includes two fixes. 

- First, the `ocurredAt` date was added to the request body to ensure the occurrence date is correctly tracked when assigning the final result. Depending on the configuration of some programs, it is required.

- Second, the `attributes` array was removed from `enrollment` payload during the perform promotion, as it was being sent unnecessarily based on our current data model. 